### PR TITLE
Fix padding in render_image

### DIFF
--- a/hypernerf/evaluation.py
+++ b/hypernerf/evaluation.py
@@ -104,6 +104,7 @@ def render_image(
       # pylint: disable=cell-var-from-loop
       chunk_pad_fn = lambda x: jnp.pad(x, ((0, padding), (0, 0)), mode='edge')
       chunk_rays_dict = tree_util.tree_map(chunk_pad_fn, chunk_rays_dict)
+      num_chunk_rays = chunk_rays_dict['origins'].shape[0]
     else:
       padding = 0
     # After padding the number of chunk_rays is always divisible by


### PR DESCRIPTION
Error: https://github.com/d2nerf/d2nerf/issues/7 

Issue:
[L116](https://github.com/d2nerf/d2nerf/blob/main/hypernerf/evaluation.py#L116) filters out the padding from `chunk_rays_dict` since `num_chunk_rays` (and hence `per_proc_rays`) is not updated after padding.

Solution:
Update `num_chunk_rays` after padding.